### PR TITLE
fix(docs): response example for POST /Convert endpoint

### DIFF
--- a/src/Timezone.WebApi/Controllers/ConvertController.cs
+++ b/src/Timezone.WebApi/Controllers/ConvertController.cs
@@ -12,7 +12,7 @@ using Timezone.Core.Services;
 public class ConvertController(ITimezoneService timezoneService) : Controller
 {
     [HttpPost]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DateTime))]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(TimeZoneConversionResultResponse))]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ErrorModel))]
     [SwaggerRequestExample(typeof(TimeZoneConversionRequest), typeof(PostConvertExamples))]
     public async Task<TimeZoneConversionResultResponse> ConvertTime(TimeZoneConversionRequest request)


### PR DESCRIPTION
The response example in the documentation(swagger) for the `POST /Convert` endpoint was not correct. This change fixes that.

No API behavior, contract, or functionality has been changed—this is purely a documentation update.

before:
![image](https://github.com/user-attachments/assets/f001b642-e2bd-4ed3-ad21-130d38f10ded)

after:
![image](https://github.com/user-attachments/assets/a617c5df-a31e-461a-a6c8-c64505ecd216)
