### PR TITLE
chore: replace SpecFlow with Reqnroll

### DIFF
--- a/tests/Timezone.FunctionalTests/ImplicitUsings.cs
+++ b/tests/Timezone.FunctionalTests/ImplicitUsings.cs
@@ -1,1 +1,1 @@
-global using TechTalk.SpecFlow;
+global using Reqnroll;

--- a/tests/Timezone.FunctionalTests/Timezone.FunctionalTests.csproj
+++ b/tests/Timezone.FunctionalTests/Timezone.FunctionalTests.csproj
@@ -4,17 +4,14 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <NoWarn>CS8600;CS8604;CS8618;CS8602;CS1998</NoWarn>
-    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
+    <PackageReference Include="Reqnroll" Version="3.3.1" />
+    <PackageReference Include="Reqnroll.NUnit" Version="3.3.1" />
     <PackageReference Include="RestSharp" Version="113.0.0" />
-    <PackageReference Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />
     <PackageReference Include="nunit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0">
       <TreatAsUsed>true</TreatAsUsed>


### PR DESCRIPTION
- SpecFlow has been deprecated as seen in https://reqnroll.net/news/2025/01/specflow-end-of-life-has-been-announced/
- This change aims to replace SpecFlow library with Reqnroll